### PR TITLE
Install yarn via npm

### DIFF
--- a/elixir-cypress-ci/Dockerfile
+++ b/elixir-cypress-ci/Dockerfile
@@ -4,7 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 RUN apt-get upgrade -y
 RUN apt-get dist-upgrade -y
-RUN apt-get install -y python3-pip postgresql-client jq nodejs bc git imagemagick brotli wkhtmltopdf bash openssh-client libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+RUN apt-get install -y python3-pip postgresql-client jq nodejs npm bc git imagemagick brotli wkhtmltopdf bash openssh-client libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 RUN npm install --global yarn
 
 RUN pip install awscli virtualenv requests boto3 --upgrade

--- a/elixir-cypress-ci/Dockerfile
+++ b/elixir-cypress-ci/Dockerfile
@@ -4,7 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 RUN apt-get upgrade -y
 RUN apt-get dist-upgrade -y
-RUN apt-get install -y python3-pip postgresql-client jq nodejs yarn bc git imagemagick brotli wkhtmltopdf bash openssh-client libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+RUN apt-get install -y python3-pip postgresql-client jq nodejs bc git imagemagick brotli wkhtmltopdf bash openssh-client libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+RUN npm install --global yarn
 
 RUN pip install awscli virtualenv requests boto3 --upgrade
 


### PR DESCRIPTION
When yarn was installed via `apt-get`, it installed version 0.32+git which is ancient. Installing it via npm to ensure we get the latest version