### PR TITLE
Add openssl to prod image

### DIFF
--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.14.2
 
-RUN apk add --no-cache imagemagick curl postgresql-client wkhtmltopdf bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation
+RUN apk add --no-cache imagemagick curl postgresql-client wkhtmltopdf bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl
 
 RUN apk upgrade --no-cache


### PR DESCRIPTION
OpenSSL is apparently required for lacework.

https://app.shortcut.com/multiverse/story/9762/ensure-that-openssl-ca-certificates-and-curl-are-installed-in-our-fargate-task-requirement-for-laceworks