### PR TITLE
Add lacework datacollector to production image

### DIFF
--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -1,5 +1,18 @@
+FROM lacework/datacollector:latest-sidecar AS lacework-collector
+
 FROM alpine:3.14.2
 
 RUN apk add --no-cache imagemagick curl postgresql-client wkhtmltopdf bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl
 
 RUN apk upgrade --no-cache
+
+COPY --from=lacework-collector /var/lib/lacework-backup /var/lib/lacework-backup
+
+# install the lacework datacollector binary
+RUN mkdir -p /var/lib/lacework && \
+        gunzip /var/lib/lacework-backup/*/datacollector-musl.gz && \
+        mv /var/lib/lacework-backup/*/datacollector-musl /var/lib/lacework/datacollector && \
+        chmod +x /var/lib/lacework/datacollector && \
+        # datacollector needs to run as root so set setuid bit
+        chmod u+s /var/lib/lacework/datacollector && \
+        rm -rf /var/lib/lacework-backup


### PR DESCRIPTION
Copy the binary from lacework's docker image then set the setuid bit.

Set the setuid bit as the datacollector needs to be run as root but we run the platform as an unprivileged user. With the setuid bit set the datacollector will be run as root regardless of who ran it.

The datacollector will be started by the docker entrypoint script.