### PR TITLE
Update to Elixir 1.13.1 and Erlang 24.2

### DIFF
--- a/.github/actions/push-image/action.yml
+++ b/.github/actions/push-image/action.yml
@@ -51,7 +51,7 @@ runs:
       run: |
         curl -L https://github.com/lacework/lacework-vulnerability-scanner/releases/latest/download/lw-scanner-linux-amd64 -o lw-scanner
         chmod +x lw-scanner
-        ./lw-scanner image evaluate ${{ inputs.image_name }} ${{ inputs.image_tag }} --build-id ${{ github.run_id }} -v=false > report.json
+        ./lw-scanner image evaluate ${{ inputs.image_name }} ${{ inputs.image_tag }} --build-id ${{ github.run_id }} -v=false --fixable > report.json
 
         cat report.json
       env:

--- a/.github/actions/push-image/action.yml
+++ b/.github/actions/push-image/action.yml
@@ -53,6 +53,8 @@ runs:
         chmod +x lw-scanner
         ./lw-scanner image evaluate ${{ inputs.image_name }} ${{ inputs.image_tag }} --build-id ${{ github.run_id }} -v=false --fixable --disable-library-package-scanning > report.json
 
+        sed -i '/INFO/d' report.json
+
         cat report.json
       env:
         LW_ACCESS_TOKEN: ${{ inputs.lacework_access_token }}

--- a/.github/actions/push-image/action.yml
+++ b/.github/actions/push-image/action.yml
@@ -51,7 +51,7 @@ runs:
       run: |
         curl -L https://github.com/lacework/lacework-vulnerability-scanner/releases/latest/download/lw-scanner-linux-amd64 -o lw-scanner
         chmod +x lw-scanner
-        ./lw-scanner image evaluate ${{ inputs.image_name }} ${{ inputs.image_tag }} --build-id ${{ github.run_id }} -v=false --fixable > report.json
+        ./lw-scanner image evaluate ${{ inputs.image_name }} ${{ inputs.image_tag }} --build-id ${{ github.run_id }} -v=false --fixable --disable-library-package-scanning > report.json
 
         cat report.json
       env:

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.12.3-erlang-24.1.2-alpine-3.14.2
+          image_tag: 1.13.1-erlang-24.2-alpine-3.14.2
           context: ./elixir-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}

--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.12.3-erlang-24.1.2-debian-bullseye-20210902-slim
+          image_tag: 1.13.1-erlang-24.2-debian-bullseye-20210902-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false

--- a/elixir-ci/Dockerfile
+++ b/elixir-ci/Dockerfile
@@ -4,6 +4,8 @@ RUN apk add --no-cache curl python3 py3-pip postgresql-client jq nodejs-current~
 
 RUN apk upgrade --no-cache
 
+RUN pip install -U pip
+
 RUN pip install awscli virtualenv requests boto3 --upgrade
 
 RUN mix local.hex --force

--- a/elixir-ci/Dockerfile
+++ b/elixir-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.12.3-erlang-24.1.2-alpine-3.14.2
+FROM hexpm/elixir:1.13.1-erlang-24.2-alpine-3.14.2
 
 RUN apk add --no-cache curl python3 py3-pip postgresql-client jq nodejs-current~=16 yarn bc git build-base imagemagick brotli wkhtmltopdf bash openssh-client docker-cli xvfb
 

--- a/elixir-cypress-ci/Dockerfile
+++ b/elixir-cypress-ci/Dockerfile
@@ -1,10 +1,37 @@
-FROM hexpm/elixir:1.12.3-erlang-24.1.2-debian-bullseye-20210902-slim
+FROM hexpm/elixir:1.13.1-erlang-24.2-debian-bullseye-20210902-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
 RUN apt-get upgrade -y
 RUN apt-get dist-upgrade -y
-RUN apt-get install -y python3-pip postgresql-client jq nodejs npm bc git imagemagick brotli wkhtmltopdf bash openssh-client libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
+RUN apt-get install -y curl bash
+
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+
+RUN apt-get install -y \
+    bc \
+    brotli \
+    git \
+    imagemagick \
+    jq \
+    libasound2 \
+    libgbm-dev \
+    libgconf-2-4 \
+    libgtk-3-0 \
+    libgtk2.0-0 \
+    libnotify-dev \
+    libnss3 \
+    libxss1 \
+    libxtst6 \
+    nodejs \
+    openssh-client \
+    postgresql-client \
+    python3-pip \
+    wkhtmltopdf \
+    xauth \
+    xvfb
+
 RUN npm install --global yarn
 
 RUN pip install awscli virtualenv requests boto3 --upgrade

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -10,7 +10,6 @@ COPY --from=lacework-collector /var/lib/lacework-backup /var/lib/lacework-backup
 
 # install the lacework datacollector binary
 RUN mkdir -p /var/lib/lacework && \
-        gunzip /var/lib/lacework-backup/*/datacollector-musl.gz && \
         mv /var/lib/lacework-backup/*/datacollector-musl /var/lib/lacework/datacollector && \
         chmod +x /var/lib/lacework/datacollector && \
         # datacollector needs to run as root so set setuid bit


### PR DESCRIPTION
### Updates:
Elixir 1.13.1
Erlang 24.2
Alpine 3.14.2
Node 16.x (cypress image)

### Notes

We can't update to Alpine 3.15 yet as wkhtmltopdf is no longer available and will have to be worked on in a separate ticket.

Lacework package scanning has to be disabled as otherwise it flags the lacework datacollector as having vulnerable dependencies.

