### PR TITLE
Upgrade prod image to alpine 3.14.3

### DIFF
--- a/.github/workflows/platform-production.yml
+++ b/.github/workflows/platform-production.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/platform-production
-          image_tag: alpine-3.14.2
+          image_tag: alpine-3.14.3
           context: ./platform-production
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -1,6 +1,6 @@
 FROM lacework/datacollector:latest-sidecar AS lacework-collector
 
-FROM alpine:3.14.2
+FROM alpine:3.14.3
 
 RUN apk add --no-cache imagemagick curl postgresql-client wkhtmltopdf bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl
 


### PR DESCRIPTION
Upgrades prod images to alpine 3.14.3 to make the lacework scanner happy.

In reality I don't think it makes any material difference since we run `apk upgrade` in the images anyway.

Alpine 3.14.2 comes with busybox 1.33.1-r3 while alpine 3.14.3 comes with busybox 1.33.1-6 which should silence these flagged vulnerabilities.

![image](https://user-images.githubusercontent.com/6924220/148527384-101f4217-e894-403d-8c43-4282d58e6d2a.png)
