### PR TITLE
Update to alpine 3.15

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.13.2-erlang-24.2.1-alpine-3.14.3
+          image_tag: 1.13.2-erlang-24.2.1-alpine-3.15.0
           context: ./elixir-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}

--- a/.github/workflows/platform-production.yml
+++ b/.github/workflows/platform-production.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/platform-production
-          image_tag: alpine-3.14.3
+          image_tag: alpine-3.15.0
           context: ./platform-production
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}

--- a/elixir-ci/Dockerfile
+++ b/elixir-ci/Dockerfile
@@ -1,6 +1,6 @@
-FROM hexpm/elixir:1.13.2-erlang-24.2.1-alpine-3.14.3
+FROM hexpm/elixir:1.13.2-erlang-24.2.1-alpine-3.15.0
 
-RUN apk add --no-cache curl python3 py3-pip postgresql-client jq nodejs-current~=16 yarn bc git build-base imagemagick brotli wkhtmltopdf bash openssh-client docker-cli xvfb
+RUN apk add --no-cache curl python3 py3-pip postgresql13-client jq nodejs~=16 yarn bc git build-base imagemagick brotli chromium bash openssh-client docker-cli xvfb
 
 RUN apk upgrade --no-cache
 

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -2,7 +2,7 @@ FROM lacework/datacollector:latest-sidecar AS lacework-collector
 
 FROM alpine:3.15.0
 
-RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl util-linux nodejs~=16
+RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq openssl util-linux nodejs~=16
 
 RUN apk upgrade --no-cache
 

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -2,7 +2,7 @@ FROM lacework/datacollector:latest-sidecar AS lacework-collector
 
 FROM alpine:3.15.0
 
-RUN apk add --no-cache imagemagick curl postgresql-client chromium bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl util-linux
+RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl util-linux
 
 RUN apk upgrade --no-cache
 

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -2,7 +2,7 @@ FROM lacework/datacollector:latest-sidecar AS lacework-collector
 
 FROM alpine:3.15.0
 
-RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl util-linux
+RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl util-linux nodejs~=16
 
 RUN apk upgrade --no-cache
 

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -1,8 +1,8 @@
 FROM lacework/datacollector:latest-sidecar AS lacework-collector
 
-FROM alpine:3.14.3
+FROM alpine:3.15.0
 
-RUN apk add --no-cache imagemagick curl postgresql-client wkhtmltopdf bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl util-linux
+RUN apk add --no-cache imagemagick curl postgresql-client chromium bash jq ttf-dejavu ttf-droid ttf-freefont ttf-liberation openssl util-linux
 
 RUN apk upgrade --no-cache
 


### PR DESCRIPTION
In doing so we had to replace wkhtmltopdf with chromium as it has been removed from the alpine repos. There will be a follow up PR on the platform to use chromium with puppeteer instead of wkhtmltopdf.