### PR TITLE
Rebuild production image daily

### DIFF
--- a/.github/workflows/platform-production.yml
+++ b/.github/workflows/platform-production.yml
@@ -9,6 +9,8 @@ on:
   workflow_dispatch:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
+  schedule:
+    - cron: '25 7 * * 1-5'
 
 jobs:
   docker:


### PR DESCRIPTION
At 07:25 on every day-of-week from Monday through Friday.

GitHub recommends not scheduling for the top of the hour as it increases chance your job will be delayed.

https://crontab.guru/#25_7_*_*_1-5

Story details: https://app.shortcut.com/multiverse/story/12483