### PR TITLE
platform-production to use 3.16

### DIFF
--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -1,6 +1,6 @@
 FROM lacework/datacollector:latest-sidecar AS lacework-collector
 
-FROM alpine:3.16.0
+FROM alpine:3.16
 
 RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq openssl util-linux nodejs~=16
 


### PR DESCRIPTION
Means patch versions can be applied without explicitly changing the Dockerfile