### PR TITLE
Add chromium to cypress image

### DIFF
--- a/elixir-cypress-ci/Dockerfile
+++ b/elixir-cypress-ci/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get install -y \
     python3-pip \
     wkhtmltopdf \
     xauth \
-    xvfb
+    xvfb \
+    chromium
 
 RUN npm install --global yarn
 


### PR DESCRIPTION
Our current version of cypress uses Electron with chromium 91 which breaks with the latest pdfjs version.

This adds chromium to the cypress image so that we can that instead of electron.