### PR TITLE
Update to latest version of Erlang & Elixir required for RabbitMQ

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.14.0-erlang-25.0.4-alpine-3.16.1
+          image_tag: 1.14.1-erlang-25.1.2-alpine-3.16.2
           context: ./elixir-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}

--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.14.0-erlang-25.0.4-debian-bullseye-20220801-slim
+          image_tag: 1.14.1-erlang-25.1.2-debian-bullseye-20221004-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false

--- a/.github/workflows/platform-production.yml
+++ b/.github/workflows/platform-production.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/platform-production
-          image_tag: alpine-3.16.1
+          image_tag: alpine-3.16.2
           context: ./platform-production
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}

--- a/elixir-ci/Dockerfile
+++ b/elixir-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.14.0-erlang-25.0.4-alpine-3.16.1
+FROM hexpm/elixir:1.14.1-erlang-25.1.2-alpine-3.16.2
 
 RUN apk add --no-cache curl python3 py3-pip postgresql13-client jq nodejs~=16 yarn bc git build-base imagemagick brotli chromium bash openssh-client docker-cli xvfb libc6-compat
 

--- a/elixir-cypress-ci/Dockerfile
+++ b/elixir-cypress-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.14.0-erlang-25.0.4-debian-bullseye-20220801-slim
+FROM hexpm/elixir:1.14.1-erlang-25.1.2-debian-bullseye-20221004-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -1,6 +1,6 @@
 FROM lacework/datacollector:latest-sidecar AS lacework-collector
 
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq openssl util-linux nodejs~=16
 


### PR DESCRIPTION
Updated base images to the latest version of Elixir & Erlang (and Alpine whilst I'm at it), as they're required for the latest version of RabbitMQ. 