### PR TITLE
Slim down cypress image

### DIFF
--- a/.github/actions/push-image/action.yml
+++ b/.github/actions/push-image/action.yml
@@ -26,20 +26,20 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ inputs.registry_password }}
 
     - name: Build and export to Docker
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         context: ${{ inputs.context }}
         platforms: linux/amd64
@@ -62,7 +62,7 @@ runs:
         LW_ACCOUNT_SUFFIX: fra.lacework.net
         LW_SCANNER_DISABLE_UPDATES: true
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: report.json
         path: report.json
@@ -78,7 +78,7 @@ runs:
         cat report.json | jq -e '.cve.info_vulnerabilities == 0' > /dev/null || (echo "info vulnerabilities found" && false)
 
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         context: ${{ inputs.context }}
         platforms: linux/amd64

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and push image
         uses: ./.github/actions/push-image

--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and push image
         uses: ./.github/actions/push-image

--- a/.github/workflows/platform-production.yml
+++ b/.github/workflows/platform-production.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and push image
         uses: ./.github/actions/push-image

--- a/elixir-cypress-ci/Dockerfile
+++ b/elixir-cypress-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 hexpm/elixir:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim
+FROM hexpm/elixir:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update -y

--- a/elixir-cypress-ci/Dockerfile
+++ b/elixir-cypress-ci/Dockerfile
@@ -1,41 +1,36 @@
-FROM hexpm/elixir:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim
+FROM --platform=linux/amd64 hexpm/elixir:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get dist-upgrade -y
+RUN apt update -y
+RUN apt upgrade -y
+RUN apt dist-upgrade -y
 
-RUN apt-get install -y curl bash
+RUN apt install -y curl bash
 
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
-RUN apt-get install -y \
-    bc \
-    brotli \
-    git \
-    imagemagick \
-    jq \
-    libasound2 \
-    libgbm-dev \
-    libgconf-2-4 \
-    libgtk-3-0 \
-    libgtk2.0-0 \
-    libnotify-dev \
-    libnss3 \
-    libxss1 \
-    libxtst6 \
+RUN apt install -y --no-install-recommends \
     nodejs \
     openssh-client \
     postgresql-client \
-    python3-pip \
-    wkhtmltopdf \
+    git \
+    imagemagick \
+
+    # cypress deps from here https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies
+
+    libgtk2.0-0 \
+    libgtk-3-0 \
+    libgbm-dev \
+    libnotify-dev \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    libxtst6 \
     xauth \
-    xvfb \
-    chromium
+    xvfb
 
-RUN npm install --global yarn
-
-RUN pip install awscli virtualenv requests boto3 --upgrade
+RUN corepack enable
 
 RUN mix local.hex --force
 RUN mix local.rebar --force

--- a/elixir-cypress-ci/Dockerfile
+++ b/elixir-cypress-ci/Dockerfile
@@ -30,6 +30,7 @@ RUN apt install -y --no-install-recommends \
     xauth \
     xvfb
 
+# Install yarn using corepack
 RUN corepack enable
 
 RUN mix local.hex --force


### PR DESCRIPTION
Basically this removes a bunch of unused dependencies which we no longer need to get cypress running.

Pull output for old image:
```
ghcr.io/multiverse-io/elixir-cypress-ci:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim:
  using image ghcr.io/multiverse-io/elixir-cypress-ci@sha256:96f41bc22982f364b9025f1e4f013b70156b11805dc851628822b62bf8a29cec
  pull stats: download 602.6MiB in 4.38s (137.6MiB/s), extract 602.5MiB in 13.041s (46.2MiB/s)
  time to create container: 331ms
```


Pull output for new image:
```
  using image multiverseio/debian-cypress-ci-testing@sha256:7359be9db60186e82ba0b5acab9949e3086f2209e459b7b1d1d1441a85b2e348
  pull stats: download 310.4MiB in 3.29s (94.33MiB/s), extract 310.2MiB in 5.968s (51.98MiB/s)
  time to create container: 70ms
```

I tested this by pushing the image to dockerhub and creating a branch which uses this new image. See here: https://app.circleci.com/pipelines/github/Multiverse-io/platform/50092/workflows/b47e554b-6869-4810-b3f5-bdcab70f8b3c/jobs/124871/parallel-runs/1?filterBy=ALL

