### PR TITLE
Explicitly install `make` and `gcc`  in the elixir-cypress image

### DIFF
--- a/elixir-cypress-ci/Dockerfile
+++ b/elixir-cypress-ci/Dockerfile
@@ -13,6 +13,8 @@ RUN apt install -y --no-install-recommends \
     nodejs \
     openssh-client \
     postgresql-client \
+    make \
+    gcc \
     git \
     imagemagick \
 


### PR DESCRIPTION
This installs `make` and `gcc` in the base elixir-cypress image, since those are needed to compile the C extensions used by `bcrypt_elixir`.

Output of building the docker image locally and checking that `make` and `gcc` are available: 

```
➜  elixir-cypress-ci git:(main)  docker build . -t elixir-cypress
[+] Building 82.0s (14/14) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 856B                                                                                                                                                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/hexpm/elixir:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim                                                                                                                                                                                                                                                             2.1s
 => [ 1/10] FROM docker.io/hexpm/elixir:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim@sha256:0f066c077a615d55f2a2cf68b01a5dafa1a9997d3abdb23a3925d28306efd27d                                                                                                                                                                                                    12.2s
 => => resolve docker.io/hexpm/elixir:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim@sha256:0f066c077a615d55f2a2cf68b01a5dafa1a9997d3abdb23a3925d28306efd27d                                                                                                                                                                                                       0.0s
 => => sha256:0f066c077a615d55f2a2cf68b01a5dafa1a9997d3abdb23a3925d28306efd27d 772B / 772B                                                                                                                                                                                                                                                                             0.0s
 => => sha256:f60231e18e77350f9a94e257305d252fa58f3328467b3a2f07285d23f500915e 1.16kB / 1.16kB                                                                                                                                                                                                                                                                         0.0s
 => => sha256:b0373dae066f1a2a943c1fe0f31379f20f4abfd79a90e2c9de0da3423f4f38a0 2.35kB / 2.35kB                                                                                                                                                                                                                                                                         0.0s
 => => sha256:df8e44b0463f16c791d040e02e9c3ef8ec2a84245d365f088a80a22a455c71e8 30.06MB / 30.06MB                                                                                                                                                                                                                                                                       9.8s
 => => sha256:6bd66208ea3e7f777de97920722d6f3a96c3ca23f0bf8a2e831925899f1bfc77 14.19MB / 14.19MB                                                                                                                                                                                                                                                                      10.3s
 => => sha256:fc3c5440db287bffeae8612b2f7b89d1339f5dbcce164f7bbbd90181c8870399 44.48MB / 44.48MB                                                                                                                                                                                                                                                                      10.4s
 => => extracting sha256:df8e44b0463f16c791d040e02e9c3ef8ec2a84245d365f088a80a22a455c71e8                                                                                                                                                                                                                                                                              1.0s
 => => sha256:cb9975256fdea29c7534223aaf759ac246b9f60d708c3d5f07b6b7d0df7e8169 5.26MB / 5.26MB                                                                                                                                                                                                                                                                        11.2s
 => => extracting sha256:6bd66208ea3e7f777de97920722d6f3a96c3ca23f0bf8a2e831925899f1bfc77                                                                                                                                                                                                                                                                              0.3s
 => => extracting sha256:fc3c5440db287bffeae8612b2f7b89d1339f5dbcce164f7bbbd90181c8870399                                                                                                                                                                                                                                                                              0.8s
 => => extracting sha256:cb9975256fdea29c7534223aaf759ac246b9f60d708c3d5f07b6b7d0df7e8169                                                                                                                                                                                                                                                                              0.1s
 => [ 2/10] RUN apt update -y                                                                                                                                                                                                                                                                                                                                          2.5s
 => [ 3/10] RUN apt upgrade -y                                                                                                                                                                                                                                                                                                                                         5.3s
 => [ 4/10] RUN apt dist-upgrade -y                                                                                                                                                                                                                                                                                                                                    0.6s
 => [ 5/10] RUN apt install -y curl bash                                                                                                                                                                                                                                                                                                                               2.5s
 => [ 6/10] RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -                                                                                                                                                                                                                                                                                                6.3s
 => [ 7/10] RUN apt install -y --no-install-recommends     nodejs     openssh-client     postgresql-client     make     gcc     git     imagemagick     libgtk2.0-0     libgtk-3-0     libgbm-dev     libnotify-dev     libgconf-2-4     libnss3     libxss1     libasound2     libxtst6     xauth     xvfb                                                           46.1s
 => [ 8/10] RUN corepack enable                                                                                                                                                                                                                                                                                                                                        0.4s
 => [ 9/10] RUN mix local.hex --force                                                                                                                                                                                                                                                                                                                                  1.0s
 => [10/10] RUN mix local.rebar --force                                                                                                                                                                                                                                                                                                                                1.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 1.8s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                1.8s
 => => writing image sha256:7d8813c8a4f822227fd8a8004a1fd18a473e6cfcbf1dd7fcf0aeb4139be968be                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/library/elixir-cypress                                                                                                                                                                                                                                                                                                                      0.0s
➜  elixir-cypress-ci git:(main)  docker run elixir-cypress which make
/usr/bin/make
➜  elixir-cypress-ci git:(main)  docker run elixir-cypress which gcc
/usr/bin/gcc
```