### PR TITLE
Install tar in the elixir-ci image

### DIFF
--- a/elixir-ci/Dockerfile
+++ b/elixir-ci/Dockerfile
@@ -1,6 +1,6 @@
 FROM hexpm/elixir:1.14.2-erlang-25.1.2-alpine-3.16.2
 
-RUN apk add --no-cache curl python3 py3-pip postgresql13-client jq nodejs~=16 yarn bc git build-base imagemagick brotli chromium bash openssh-client docker-cli xvfb libc6-compat
+RUN apk add --no-cache curl python3 py3-pip postgresql13-client jq nodejs~=16 yarn bc git build-base imagemagick brotli chromium bash openssh-client docker-cli xvfb libc6-compat tar
 
 RUN apk upgrade --no-cache
 


### PR DESCRIPTION
`tar` is needed so that we can archive all the test coverage reports and export it as a single build artefact in CircleCI.

Output of building the image locally and checking that `tar` is available:

```bash
➜  elixir-ci git:(add-tar-to-elixir-ci-image) ✗ docker build . -t elixir-ci
[+] Building 64.6s (11/11) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 460B                                                                                                                                                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/hexpm/elixir:1.14.2-erlang-25.1.2-alpine-3.16.2                                                                                                                                                                                                                                                                             2.0s
 => [1/7] FROM docker.io/hexpm/elixir:1.14.2-erlang-25.1.2-alpine-3.16.2@sha256:a2cac1ee5a574831c8355be2516dc430f3fe32efef3eaf62565fdb3d55ba5d81                                                                                                                                                                                                                       5.8s
 => => resolve docker.io/hexpm/elixir:1.14.2-erlang-25.1.2-alpine-3.16.2@sha256:a2cac1ee5a574831c8355be2516dc430f3fe32efef3eaf62565fdb3d55ba5d81                                                                                                                                                                                                                       0.0s
 => => sha256:ddae4ff330fe4b06f5828b31a63becd5d7c8611206bfa508f59cfad010758a9c 31.96MB / 31.96MB                                                                                                                                                                                                                                                                       5.1s
 => => sha256:a2cac1ee5a574831c8355be2516dc430f3fe32efef3eaf62565fdb3d55ba5d81 772B / 772B                                                                                                                                                                                                                                                                             0.0s
 => => sha256:46918dfe8109d0fc4f6411ca784a36930cbbc40fb362438fc98c88c9253466ca 1.16kB / 1.16kB                                                                                                                                                                                                                                                                         0.0s
 => => sha256:ae92ee5a7a7f3815de9f68c76db7a7e385748c84edb048d8dc984c6fb80766ae 2.38kB / 2.38kB                                                                                                                                                                                                                                                                         0.0s
 => => sha256:9b18e9b68314027565b90ff6189d65942c0f7986da80df008b8431276885218e 2.71MB / 2.71MB                                                                                                                                                                                                                                                                         0.5s
 => => sha256:37ab3d3d0c174498e62e66e5e5296b4a292c60f4176948beb1bcfba066a32354 1.69MB / 1.69MB                                                                                                                                                                                                                                                                         2.5s
 => => extracting sha256:9b18e9b68314027565b90ff6189d65942c0f7986da80df008b8431276885218e                                                                                                                                                                                                                                                                              0.1s
 => => sha256:c11b0037096d8e9a033d0bb7109df2eb5bc0877d91c7cbf4745cac507e7ab6bc 5.26MB / 5.26MB                                                                                                                                                                                                                                                                         2.3s
 => => extracting sha256:37ab3d3d0c174498e62e66e5e5296b4a292c60f4176948beb1bcfba066a32354                                                                                                                                                                                                                                                                              0.1s
 => => extracting sha256:ddae4ff330fe4b06f5828b31a63becd5d7c8611206bfa508f59cfad010758a9c                                                                                                                                                                                                                                                                              0.5s
 => => extracting sha256:c11b0037096d8e9a033d0bb7109df2eb5bc0877d91c7cbf4745cac507e7ab6bc                                                                                                                                                                                                                                                                              0.1s
 => [2/7] RUN apk add --no-cache curl python3 py3-pip postgresql13-client jq nodejs~=16 yarn bc git build-base imagemagick brotli chromium bash openssh-client docker-cli xvfb libc6-compat tar                                                                                                                                                                       37.4s
 => [3/7] RUN apk upgrade --no-cache                                                                                                                                                                                                                                                                                                                                   1.0s
 => [4/7] RUN pip install -U pip                                                                                                                                                                                                                                                                                                                                       2.7s
 => [5/7] RUN pip install awscli virtualenv requests boto3 --upgrade                                                                                                                                                                                                                                                                                                  12.0s
 => [6/7] RUN mix local.hex --force                                                                                                                                                                                                                                                                                                                                    1.0s
 => [7/7] RUN mix local.rebar --force                                                                                                                                                                                                                                                                                                                                  0.9s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                 1.9s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                                1.9s
 => => writing image sha256:4079d2db722d1d0fa4a8372098f664d8aef381a9232598a82d53744c0ab626ff                                                                                                                                                                                                                                                                           0.0s
 => => naming to docker.io/library/elixir-ci                                                                                                                                                                                                                                                                                                                           0.0s
➜  elixir-ci git:(add-tar-to-elixir-ci-image) ✗ docker run elixir-ci which tar
/usr/bin/tar
```