### PR TITLE
update libvpx and snappy

### DIFF
--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -4,7 +4,7 @@ FROM lacework/datacollector:latest-sidecar AS lacework-collector
 ARG ALPINE_VERSION
 FROM alpine:${ALPINE_VERSION}
 
-RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq openssl util-linux nodejs~=18
+RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq openssl util-linux nodejs~=18 snappy libvpx
 
 RUN apk upgrade --no-cache
 

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -4,7 +4,7 @@ FROM lacework/datacollector:latest-sidecar AS lacework-collector
 ARG ALPINE_VERSION
 FROM alpine:${ALPINE_VERSION}
 
-RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq openssl util-linux nodejs~=18 snappy libvpx
+RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq openssl util-linux nodejs~=18 knplabs-snappy libvpx
 
 RUN apk upgrade --no-cache
 


### PR DESCRIPTION
Critical severity
Snappy: 1.1.10-r1
https://security.alpinelinux.org/vuln/CVE-2023-28115
Upgrade to 1.4.2 to fix

nodejs: 18.20.1-r0
https://security.alpinelinux.org/vuln/CVE-2023-39332
Upgrade to 20.8.0
___
High severity
Libvpx: 1.13.0.r2
https://security.alpinelinux.org/vuln/CVE-2023-44488
upgrade to 1.13.1

Postgres-common: 1.2-r1
https://security.alpinelinux.org/vuln/CVE-2019-3466
upgrade to 210? 
