### PR TITLE
Upgrade alpine 3.18 -> 3.20

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -43,17 +43,17 @@ jobs:
             ERLANG_VERSION=26.2.5.1
             DEBIAN_VERSION=bookworm-20240701-slim
 
-      - name: Build and push Alpine image otp 26
+      - name: Build and push Alpine image otp 26 elixir 1.14
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.14.5-erlang-26.2.5-alpine-3.20.1
+          image_tag: 1.14.5-erlang-26.2.5.2-alpine-3.20.1
           context: ./elixir-ci/alpine
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.14.5
-            ERLANG_VERSION=26.2.5
+            ERLANG_VERSION=26.2.5.2
             ALPINE_VERSION=3.20.1
 
       - name: Build and push Debian image

--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -31,16 +31,16 @@ jobs:
             ERLANG_VERSION=26.1.2
             DEBIAN_VERSION=bullseye-20231009-slim
 
-      - name: Build and push image otp 26
+      - name: Build and push image otp 26 elixir 1.14
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.14.5-erlang-26.1.2-debian-bookworm-20231009-slim
+          image_tag: 1.14.5-erlang-26.2.5.2-debian-bookworm-20240701-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.14.5
-            ERLANG_VERSION=26.1.2
-            DEBIAN_VERSION=bookworm-20231009-slim
+            ERLANG_VERSION=26.2.5.2
+            DEBIAN_VERSION=bookworm-20240701-slim

--- a/.github/workflows/platform-production.yml
+++ b/.github/workflows/platform-production.yml
@@ -19,17 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build and push image alpine 3.18.0
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/platform-production
-          image_tag: alpine-3.18.0
-          context: ./platform-production
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ALPINE_VERSION=3.18.0
-
       - name: Build and push image alpine 3.18.4
         uses: ./.github/actions/push-image
         with:
@@ -40,6 +29,17 @@ jobs:
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ALPINE_VERSION=3.18.4
+
+      - name: Build and push image alpine 3.20.1
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/platform-production
+          image_tag: alpine-3.20.1
+          context: ./platform-production
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ALPINE_VERSION=3.20.1
 
       - name: Switch to keepalive branch
         uses: actions/checkout@v4

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -4,7 +4,7 @@ FROM lacework/datacollector:latest-sidecar AS lacework-collector
 ARG ALPINE_VERSION
 FROM alpine:${ALPINE_VERSION}
 
-RUN apk add --no-cache imagemagick curl postgresql14-client chromium bash jq openssl util-linux nodejs~=20
+RUN apk add --no-cache imagemagick curl postgresql14-client chromium bash jq openssl util-linux nodejs
 
 RUN apk upgrade --no-cache
 

--- a/platform-production/Dockerfile
+++ b/platform-production/Dockerfile
@@ -4,7 +4,7 @@ FROM lacework/datacollector:latest-sidecar AS lacework-collector
 ARG ALPINE_VERSION
 FROM alpine:${ALPINE_VERSION}
 
-RUN apk add --no-cache imagemagick curl postgresql13-client chromium bash jq openssl util-linux nodejs~=18
+RUN apk add --no-cache imagemagick curl postgresql14-client chromium bash jq openssl util-linux nodejs~=20
 
 RUN apk upgrade --no-cache
 


### PR DESCRIPTION
- Removes build for `platform-production:alpine-3.18.0` as no longer used in platform
- Adds build for `platform-production:alpine-3.20.1`
- Updates 3.18 CI images to 3.20
- Updates erlang version to 26.2.5.2