### PR TITLE
add elixir 1.15.8 and erlang 26.2.5.2 for cypress image

### DIFF
--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -19,14 +19,14 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.15.8-erlang-26.2.5.2-debian-bookworm-20240701-slim
+          image_tag: 1.15.8-erlang-26.2.5-debian-bookworm-20240701-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.15.8
-            ERLANG_VERSION=26.2.5.2
+            ERLANG_VERSION=26.2.5
             DEBIAN_VERSION=bookworm-20240701-slim
 
       - name: Build and push image otp 26 elixir 1.14

--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.15.8-erlang-26.2.5-debian-bookworm-20240701-slim
+          image_tag: 1.15.8-erlang-26.2.5-debian-bookworm-20240612-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
@@ -27,7 +27,7 @@ jobs:
           build_args: |
             ELIXIR_VERSION=1.15.8
             ERLANG_VERSION=26.2.5
-            DEBIAN_VERSION=bookworm-20240701-slim
+            DEBIAN_VERSION=bookworm-20240612-slim
 
       - name: Build and push image otp 26 elixir 1.14
         uses: ./.github/actions/push-image

--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -19,15 +19,15 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.15.7-erlang-26.1.2-debian-bullseye-20231009-slim
+          image_tag: 1.15.8-erlang-26.2.5.2-debian-bookworm-20240701-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
-            ELIXIR_VERSION=1.15.7
-            ERLANG_VERSION=26.1.2
-            DEBIAN_VERSION=bullseye-20231009-slim
+            ELIXIR_VERSION=1.15.8
+            ERLANG_VERSION=26.2.5.2
+            DEBIAN_VERSION=bookworm-20240701-slim
 
       - name: Build and push image otp 26 elixir 1.14
         uses: ./.github/actions/push-image


### PR DESCRIPTION
https://hub.docker.com/layers/hexpm/elixir/1.15.8-erlang-26.2.5-debian-bookworm-20240612-slim/images/sha256-ba57458c92c2c76d3ab06433d4116245cd0712d75a266baa4caf4199be0f804c?context=explore