### PR TITLE
Fix CVE-2025-32433: Bump all Erlang 26 versions to 26.2.5.13

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -19,14 +19,14 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.15.8-erlang-26.2.5.11-alpine-3.20.1
+          image_tag: 1.15.8-erlang-26.2.5.11-alpine-3.20.6
           context: ./elixir-ci/alpine
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.15.8
             ERLANG_VERSION=26.2.5.11
-            ALPINE_VERSION=3.20.1
+            ALPINE_VERSION=3.20.6
 
       - name: Build and push Debian image otp 26 elixir 1.17
         uses: ./.github/actions/push-image
@@ -58,14 +58,14 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.14.5-erlang-26.2.5.11-alpine-3.20.1
+          image_tag: 1.14.5-erlang-26.2.5.11-alpine-3.20.6
           context: ./elixir-ci/alpine
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.14.5
             ERLANG_VERSION=26.2.5.11
-            ALPINE_VERSION=3.20.1
+            ALPINE_VERSION=3.20.6
 
       - name: Build and push Debian image
         uses: ./.github/actions/push-image

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -19,63 +19,63 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.15.8-erlang-26.2.5-alpine-3.20.1
+          image_tag: 1.15.8-erlang-26.2.5.11-alpine-3.20.1
           context: ./elixir-ci/alpine
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.15.8
-            ERLANG_VERSION=26.2.5
+            ERLANG_VERSION=26.2.5.11
             ALPINE_VERSION=3.20.1
 
       - name: Build and push Debian image otp 26 elixir 1.17
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.17.2-erlang-26.2.5.1-debian-bookworm-20240701-slim
+          image_tag: 1.17.2-erlang-26.2.5.11-debian-bookworm-20240701-slim
           context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.17.2
-            ERLANG_VERSION=26.2.5.1
+            ERLANG_VERSION=26.2.5.11
             DEBIAN_VERSION=bookworm-20240701-slim
 
       - name: Build and push Debian image otp 26 elixir 1.18
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.18.1-erlang-26.2.5.6-debian-bookworm-20241223-slim
+          image_tag: 1.18.1-erlang-26.2.5.11-debian-bookworm-20241223-slim
           context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.18.1
-            ERLANG_VERSION=26.2.5.6
+            ERLANG_VERSION=26.2.5.11
             DEBIAN_VERSION=bookworm-20241223-slim
 
       - name: Build and push Alpine image otp 26 elixir 1.14
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.14.5-erlang-26.2.5.2-alpine-3.20.1
+          image_tag: 1.14.5-erlang-26.2.5.11-alpine-3.20.1
           context: ./elixir-ci/alpine
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.14.5
-            ERLANG_VERSION=26.2.5.2
+            ERLANG_VERSION=26.2.5.11
             ALPINE_VERSION=3.20.1
 
       - name: Build and push Debian image
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.16.0-erlang-26.2.1-debian-bookworm-20231009-slim
+          image_tag: 1.16.0-erlang-26.2.5.11-debian-bookworm-20231009-slim
           context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.16.0
-            ERLANG_VERSION=26.2.1
+            ERLANG_VERSION=26.2.5.11
             DEBIAN_VERSION=bookworm-20231009-slim

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -32,27 +32,27 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.17.2-erlang-26.2.5.11-debian-bookworm-20240701-slim
+          image_tag: 1.17.3-erlang-26.2.5.11-debian-bookworm-20250428-slim
           context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
-            ELIXIR_VERSION=1.17.2
+            ELIXIR_VERSION=1.17.3
             ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bookworm-20240701-slim
+            DEBIAN_VERSION=bookworm-20250428-slim
 
       - name: Build and push Debian image otp 26 elixir 1.18
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.18.1-erlang-26.2.5.11-debian-bookworm-20241223-slim
+          image_tag: 1.18.3-erlang-26.2.5.11-debian-bookworm-20250428-slim
           context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
-            ELIXIR_VERSION=1.18.1
+            ELIXIR_VERSION=1.18.3
             ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bookworm-20241223-slim
+            DEBIAN_VERSION=bookworm-20250428-slim
 
       - name: Build and push Alpine image otp 26 elixir 1.14
         uses: ./.github/actions/push-image
@@ -71,11 +71,11 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.16.0-erlang-26.2.5.11-debian-bookworm-20231009-slim
+          image_tag: 1.16.3-erlang-26.2.5.11-debian-bookworm-20250428-slim
           context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
-            ELIXIR_VERSION=1.16.0
+            ELIXIR_VERSION=1.16.3
             ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bookworm-20231009-slim
+            DEBIAN_VERSION=bookworm-20250428-slim

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -19,63 +19,63 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.15.8-erlang-26.2.5.11-alpine-3.20.6
+          image_tag: 1.15.8-erlang-26.2.5.13-alpine-3.20.6
           context: ./elixir-ci/alpine
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.15.8
-            ERLANG_VERSION=26.2.5.11
+            ERLANG_VERSION=26.2.5.13
             ALPINE_VERSION=3.20.6
 
       - name: Build and push Debian image otp 26 elixir 1.17
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.17.3-erlang-26.2.5.11-debian-bookworm-20250428-slim
+          image_tag: 1.17.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
           context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.17.3
-            ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bookworm-20250428-slim
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
 
       - name: Build and push Debian image otp 26 elixir 1.18
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.18.3-erlang-26.2.5.11-debian-bookworm-20250428-slim
+          image_tag: 1.18.4-erlang-26.2.5.13-debian-bookworm-20250630-slim
           context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
-            ELIXIR_VERSION=1.18.3
-            ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bookworm-20250428-slim
+            ELIXIR_VERSION=1.18.4
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
 
       - name: Build and push Alpine image otp 26 elixir 1.14
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.14.5-erlang-26.2.5.11-alpine-3.20.6
+          image_tag: 1.14.5-erlang-26.2.5.13-alpine-3.20.6
           context: ./elixir-ci/alpine
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.14.5
-            ERLANG_VERSION=26.2.5.11
+            ERLANG_VERSION=26.2.5.13
             ALPINE_VERSION=3.20.6
 
       - name: Build and push Debian image
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.16.3-erlang-26.2.5.11-debian-bookworm-20250428-slim
+          image_tag: 1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
           context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.16.3
-            ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bookworm-20250428-slim
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim

--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -19,26 +19,26 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.15.7-erlang-26.1.2-debian-bullseye-20231009-slim
+          image_tag: 1.15.7-erlang-26.2.5.11-debian-bullseye-20231009-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.15.7
-            ERLANG_VERSION=26.1.2
+            ERLANG_VERSION=26.2.5.11
             DEBIAN_VERSION=bullseye-20231009-slim
 
       - name: Build and push image otp 26 elixir 1.14
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.14.5-erlang-26.2.5.2-debian-bookworm-20240701-slim
+          image_tag: 1.14.5-erlang-26.2.5.11-debian-bookworm-20240701-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.14.5
-            ERLANG_VERSION=26.2.5.2
+            ERLANG_VERSION=26.2.5.11
             DEBIAN_VERSION=bookworm-20240701-slim

--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -19,26 +19,26 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.15.8-erlang-26.2.5.11-debian-bookworm-20250428-slim
+          image_tag: 1.15.8-erlang-26.2.5.13-debian-bookworm-20250630-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.15.8
-            ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bookworm-20250428-slim
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
 
       - name: Build and push image otp 26 elixir 1.14
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.14.5-erlang-26.2.5.11-debian-bookworm-20250428-slim
+          image_tag: 1.14.5-erlang-26.2.5.13-debian-bookworm-20250630-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.14.5
-            ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bookworm-20250428-slim
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim

--- a/.github/workflows/elixir-cypress-ci.yml
+++ b/.github/workflows/elixir-cypress-ci.yml
@@ -3,7 +3,7 @@ name: elixir-cypress-ci
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
@@ -19,21 +19,21 @@ jobs:
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.15.7-erlang-26.2.5.11-debian-bullseye-20231009-slim
+          image_tag: 1.15.8-erlang-26.2.5.11-debian-bookworm-20250428-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
-            ELIXIR_VERSION=1.15.7
+            ELIXIR_VERSION=1.15.8
             ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bullseye-20231009-slim
+            DEBIAN_VERSION=bookworm-20250428-slim
 
       - name: Build and push image otp 26 elixir 1.14
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-cypress-ci
-          image_tag: 1.14.5-erlang-26.2.5.11-debian-bookworm-20240701-slim
+          image_tag: 1.14.5-erlang-26.2.5.11-debian-bookworm-20250428-slim
           context: ./elixir-cypress-ci
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           fail_on_security_vulnerabilities: false
@@ -41,4 +41,4 @@ jobs:
           build_args: |
             ELIXIR_VERSION=1.14.5
             ERLANG_VERSION=26.2.5.11
-            DEBIAN_VERSION=bookworm-20240701-slim
+            DEBIAN_VERSION=bookworm-20250428-slim

--- a/.github/workflows/platform-production.yml
+++ b/.github/workflows/platform-production.yml
@@ -3,12 +3,12 @@ name: platform-production
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
   schedule:
-    - cron: '25 7 * * 1-5'
+    - cron: "25 7 * * 1-5"
 
 jobs:
   docker:
@@ -17,27 +17,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build and push image alpine 3.18.4
+      - name: Build and push image alpine 3.18.12
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/platform-production
-          image_tag: alpine-3.18.4
+          image_tag: alpine-3.18.12
           context: ./platform-production
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
-            ALPINE_VERSION=3.18.4
+            ALPINE_VERSION=3.18.12
 
-      - name: Build and push image alpine 3.20.1
+      - name: Build and push image alpine 3.20.6
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/platform-production
-          image_tag: alpine-3.20.1
+          image_tag: alpine-3.20.6
           context: ./platform-production
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
-            ALPINE_VERSION=3.20.1
+            ALPINE_VERSION=3.20.6
 
       - name: Switch to keepalive branch
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Bump all Erlang 26 versions to 26.2.5.13 to fix CVE-2025-32433

See: https://www.cve.org/CVERecord?id=CVE-2025-32433

## Final output images

Here are all the Docker images that the CI workflows build and push to `ghcr.io/multiverse-io/`:

### elixir-ci

- ghcr.io/multiverse-io/elixir-ci:1.15.8-erlang-26.2.5.13-alpine-3.20.6
- ghcr.io/multiverse-io/elixir-ci:1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
- ghcr.io/multiverse-io/elixir-ci:1.17.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
- ghcr.io/multiverse-io/elixir-ci:1.18.4-erlang-26.2.5.13-debian-bookworm-20250630-slim
- ghcr.io/multiverse-io/elixir-ci:1.14.5-erlang-26.2.5.13-alpine-3.20.6

### elixir-cypress-ci
- ghcr.io/multiverse-io/elixir-cypress-ci:1.15.8-erlang-26.2.5.13-debian-bookworm-20250630-slim
- ghcr.io/multiverse-io/elixir-cypress-ci:1.14.5-erlang-26.2.5.13-debian-bookworm-20250630-slim

### platform-production
- ghcr.io/multiverse-io/platform-production:alpine-3.18.12
- ghcr.io/multiverse-io/platform-production:alpine-3.20.6

---

### Summary
- **Elixir Versions**: 1.14.5, 1.15.8, 1.16.3, 1.17.3, 1.18.4
- **Erlang Version**: 26.2.5.13 (across all Elixir images)
- **Base Images**: Alpine 3.20.6, Debian bookworm-20250630-slim
- **Alpine Platform**: 3.18.12, 3.20.6
