### PR TITLE
Remove keepalive workflow

### DIFF
--- a/.github/workflows/platform-production.yml
+++ b/.github/workflows/platform-production.yml
@@ -38,13 +38,3 @@ jobs:
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ALPINE_VERSION=3.20.6
-
-      - name: Switch to keepalive branch
-        uses: actions/checkout@v4
-        with:
-          ref: keepalive
-
-      - name: Prevent GitHub from disabling workflow due to inactivity
-        uses: gautamkrishnar/keepalive-workflow@v1
-        with:
-          committer_email: engineering@multiverse.io


### PR DESCRIPTION
This action has been disabled and causes the build for the platform-production image to break