### PR TITLE
Add elixir-ci image for debian otp 26 elixir 1.15

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -15,70 +15,70 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build and push Alpine image otp 26 elixir 1.15
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.15.8-erlang-26.2.5.13-alpine-3.20.6
-          context: ./elixir-ci/alpine
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ELIXIR_VERSION=1.15.8
-            ERLANG_VERSION=26.2.5.13
-            ALPINE_VERSION=3.20.6
+      # - name: Build and push Alpine image otp 26 elixir 1.15
+      #   uses: ./.github/actions/push-image
+      #   with:
+      #     image_name: ghcr.io/multiverse-io/elixir-ci
+      #     image_tag: 1.15.8-erlang-26.2.5.13-alpine-3.20.6
+      #     context: ./elixir-ci/alpine
+      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
+      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+      #     build_args: |
+      #       ELIXIR_VERSION=1.15.8
+      #       ERLANG_VERSION=26.2.5.13
+      #       ALPINE_VERSION=3.20.6
 
-      - name: Build and push Debian image otp 26 elixir 1.17
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.17.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
-          context: ./elixir-ci/debian
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ELIXIR_VERSION=1.17.3
-            ERLANG_VERSION=26.2.5.13
-            DEBIAN_VERSION=bookworm-20250630-slim
+      # - name: Build and push Debian image otp 26 elixir 1.17
+      #   uses: ./.github/actions/push-image
+      #   with:
+      #     image_name: ghcr.io/multiverse-io/elixir-ci
+      #     image_tag: 1.17.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
+      #     context: ./elixir-ci/debian
+      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
+      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+      #     build_args: |
+      #       ELIXIR_VERSION=1.17.3
+      #       ERLANG_VERSION=26.2.5.13
+      #       DEBIAN_VERSION=bookworm-20250630-slim
 
-      - name: Build and push Debian image otp 26 elixir 1.18
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.18.4-erlang-26.2.5.13-debian-bookworm-20250630-slim
-          context: ./elixir-ci/debian
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ELIXIR_VERSION=1.18.4
-            ERLANG_VERSION=26.2.5.13
-            DEBIAN_VERSION=bookworm-20250630-slim
+      # - name: Build and push Debian image otp 26 elixir 1.18
+      #   uses: ./.github/actions/push-image
+      #   with:
+      #     image_name: ghcr.io/multiverse-io/elixir-ci
+      #     image_tag: 1.18.4-erlang-26.2.5.13-debian-bookworm-20250630-slim
+      #     context: ./elixir-ci/debian
+      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
+      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+      #     build_args: |
+      #       ELIXIR_VERSION=1.18.4
+      #       ERLANG_VERSION=26.2.5.13
+      #       DEBIAN_VERSION=bookworm-20250630-slim
 
-      - name: Build and push Alpine image otp 26 elixir 1.14
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.14.5-erlang-26.2.5.13-alpine-3.20.6
-          context: ./elixir-ci/alpine
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ELIXIR_VERSION=1.14.5
-            ERLANG_VERSION=26.2.5.13
-            ALPINE_VERSION=3.20.6
+      # - name: Build and push Alpine image otp 26 elixir 1.14
+      #   uses: ./.github/actions/push-image
+      #   with:
+      #     image_name: ghcr.io/multiverse-io/elixir-ci
+      #     image_tag: 1.14.5-erlang-26.2.5.13-alpine-3.20.6
+      #     context: ./elixir-ci/alpine
+      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
+      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+      #     build_args: |
+      #       ELIXIR_VERSION=1.14.5
+      #       ERLANG_VERSION=26.2.5.13
+      #       ALPINE_VERSION=3.20.6
 
-      - name: Build and push Debian image otp 26 elixir 1.16
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
-          context: ./elixir-ci/debian
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ELIXIR_VERSION=1.16.3
-            ERLANG_VERSION=26.2.5.13
-            DEBIAN_VERSION=bookworm-20250630-slim
+      # - name: Build and push Debian image otp 26 elixir 1.16
+      #   uses: ./.github/actions/push-image
+      #   with:
+      #     image_name: ghcr.io/multiverse-io/elixir-ci
+      #     image_tag: 1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
+      #     context: ./elixir-ci/debian
+      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
+      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+      #     build_args: |
+      #       ELIXIR_VERSION=1.16.3
+      #       ERLANG_VERSION=26.2.5.13
+      #       DEBIAN_VERSION=bookworm-20250630-slim
 
       - name: Build and push Debian image otp 26 elixir 1.15
         uses: ./.github/actions/push-image

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -1,5 +1,9 @@
 name: elixir-ci
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -9,24 +9,37 @@ on:
     types: [assigned, opened, synchronize, reopened]
 
 jobs:
-  docker:
+  debian:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build and push Alpine image otp 26 elixir 1.15
+      - name: Build and push Debian image otp 26 elixir 1.15
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.15.8-erlang-26.2.5.13-alpine-3.20.6
-          context: ./elixir-ci/alpine
+          image_tag: 1.15.8-erlang-26.2.5.13-debian-bookworm-20250630-slim
+          context: ./elixir-ci/debian
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.15.8
             ERLANG_VERSION=26.2.5.13
-            ALPINE_VERSION=3.20.6
+            DEBIAN_VERSION=bookworm-20250630-slim
+
+      - name: Build and push Debian image otp 26 elixir 1.16
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
+          context: ./elixir-ci/debian
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.16.3
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
 
       - name: Build and push Debian image otp 26 elixir 1.17
         uses: ./.github/actions/push-image
@@ -54,6 +67,12 @@ jobs:
             ERLANG_VERSION=26.2.5.13
             DEBIAN_VERSION=bookworm-20250630-slim
 
+  alpine:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Build and push Alpine image otp 26 elixir 1.14
         uses: ./.github/actions/push-image
         with:
@@ -67,28 +86,16 @@ jobs:
             ERLANG_VERSION=26.2.5.13
             ALPINE_VERSION=3.20.6
 
-      - name: Build and push Debian image otp 26 elixir 1.16
+      - name: Build and push Alpine image otp 26 elixir 1.15
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
-          context: ./elixir-ci/debian
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ELIXIR_VERSION=1.16.3
-            ERLANG_VERSION=26.2.5.13
-            DEBIAN_VERSION=bookworm-20250630-slim
-
-      - name: Build and push Debian image otp 26 elixir 1.15
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.15.8-erlang-26.2.5.13-debian-bookworm-20250630-slim
-          context: ./elixir-ci/debian
+          image_tag: 1.15.8-erlang-26.2.5.13-alpine-3.20.6
+          context: ./elixir-ci/alpine
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.15.8
             ERLANG_VERSION=26.2.5.13
-            DEBIAN_VERSION=bookworm-20250630-slim
+            ALPINE_VERSION=3.20.6
+

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -15,70 +15,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # - name: Build and push Alpine image otp 26 elixir 1.15
-      #   uses: ./.github/actions/push-image
-      #   with:
-      #     image_name: ghcr.io/multiverse-io/elixir-ci
-      #     image_tag: 1.15.8-erlang-26.2.5.13-alpine-3.20.6
-      #     context: ./elixir-ci/alpine
-      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
-      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-      #     build_args: |
-      #       ELIXIR_VERSION=1.15.8
-      #       ERLANG_VERSION=26.2.5.13
-      #       ALPINE_VERSION=3.20.6
+      - name: Build and push Alpine image otp 26 elixir 1.14
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.14.5-erlang-26.2.5.13-alpine-3.20.6
+          context: ./elixir-ci/alpine
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.14.5
+            ERLANG_VERSION=26.2.5.13
+            ALPINE_VERSION=3.20.6
 
-      # - name: Build and push Debian image otp 26 elixir 1.17
-      #   uses: ./.github/actions/push-image
-      #   with:
-      #     image_name: ghcr.io/multiverse-io/elixir-ci
-      #     image_tag: 1.17.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
-      #     context: ./elixir-ci/debian
-      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
-      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-      #     build_args: |
-      #       ELIXIR_VERSION=1.17.3
-      #       ERLANG_VERSION=26.2.5.13
-      #       DEBIAN_VERSION=bookworm-20250630-slim
-
-      # - name: Build and push Debian image otp 26 elixir 1.18
-      #   uses: ./.github/actions/push-image
-      #   with:
-      #     image_name: ghcr.io/multiverse-io/elixir-ci
-      #     image_tag: 1.18.4-erlang-26.2.5.13-debian-bookworm-20250630-slim
-      #     context: ./elixir-ci/debian
-      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
-      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-      #     build_args: |
-      #       ELIXIR_VERSION=1.18.4
-      #       ERLANG_VERSION=26.2.5.13
-      #       DEBIAN_VERSION=bookworm-20250630-slim
-
-      # - name: Build and push Alpine image otp 26 elixir 1.14
-      #   uses: ./.github/actions/push-image
-      #   with:
-      #     image_name: ghcr.io/multiverse-io/elixir-ci
-      #     image_tag: 1.14.5-erlang-26.2.5.13-alpine-3.20.6
-      #     context: ./elixir-ci/alpine
-      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
-      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-      #     build_args: |
-      #       ELIXIR_VERSION=1.14.5
-      #       ERLANG_VERSION=26.2.5.13
-      #       ALPINE_VERSION=3.20.6
-
-      # - name: Build and push Debian image otp 26 elixir 1.16
-      #   uses: ./.github/actions/push-image
-      #   with:
-      #     image_name: ghcr.io/multiverse-io/elixir-ci
-      #     image_tag: 1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
-      #     context: ./elixir-ci/debian
-      #     registry_password: ${{ secrets.GITHUB_TOKEN }}
-      #     lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-      #     build_args: |
-      #       ELIXIR_VERSION=1.16.3
-      #       ERLANG_VERSION=26.2.5.13
-      #       DEBIAN_VERSION=bookworm-20250630-slim
+      - name: Build and push Alpine image otp 26 elixir 1.15
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.15.8-erlang-26.2.5.13-alpine-3.20.6
+          context: ./elixir-ci/alpine
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.15.8
+            ERLANG_VERSION=26.2.5.13
+            ALPINE_VERSION=3.20.6
 
       - name: Build and push Debian image otp 26 elixir 1.15
         uses: ./.github/actions/push-image
@@ -90,5 +51,44 @@ jobs:
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.15.8
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
+
+      - name: Build and push Debian image otp 26 elixir 1.16
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
+          context: ./elixir-ci/debian
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.16.3
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
+
+      - name: Build and push Debian image otp 26 elixir 1.17
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.17.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
+          context: ./elixir-ci/debian
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.17.3
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
+
+      - name: Build and push Debian image otp 26 elixir 1.18
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.18.4-erlang-26.2.5.13-debian-bookworm-20250630-slim
+          context: ./elixir-ci/debian
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.18.4
             ERLANG_VERSION=26.2.5.13
             DEBIAN_VERSION=bookworm-20250630-slim

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -15,19 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build and push Alpine image otp 26 elixir 1.14
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.14.5-erlang-26.2.5.13-alpine-3.20.6
-          context: ./elixir-ci/alpine
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ELIXIR_VERSION=1.14.5
-            ERLANG_VERSION=26.2.5.13
-            ALPINE_VERSION=3.20.6
-
       - name: Build and push Alpine image otp 26 elixir 1.15
         uses: ./.github/actions/push-image
         with:
@@ -40,32 +27,6 @@ jobs:
             ELIXIR_VERSION=1.15.8
             ERLANG_VERSION=26.2.5.13
             ALPINE_VERSION=3.20.6
-
-      - name: Build and push Debian image otp 26 elixir 1.15
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.15.8-erlang-26.2.5.13-debian-bookworm-20250630-slim
-          context: ./elixir-ci/debian
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ELIXIR_VERSION=1.15.8
-            ERLANG_VERSION=26.2.5.13
-            DEBIAN_VERSION=bookworm-20250630-slim
-
-      - name: Build and push Debian image otp 26 elixir 1.16
-        uses: ./.github/actions/push-image
-        with:
-          image_name: ghcr.io/multiverse-io/elixir-ci
-          image_tag: 1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
-          context: ./elixir-ci/debian
-          registry_password: ${{ secrets.GITHUB_TOKEN }}
-          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
-          build_args: |
-            ELIXIR_VERSION=1.16.3
-            ERLANG_VERSION=26.2.5.13
-            DEBIAN_VERSION=bookworm-20250630-slim
 
       - name: Build and push Debian image otp 26 elixir 1.17
         uses: ./.github/actions/push-image
@@ -90,5 +51,44 @@ jobs:
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.18.4
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
+
+      - name: Build and push Alpine image otp 26 elixir 1.14
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.14.5-erlang-26.2.5.13-alpine-3.20.6
+          context: ./elixir-ci/alpine
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.14.5
+            ERLANG_VERSION=26.2.5.13
+            ALPINE_VERSION=3.20.6
+
+      - name: Build and push Debian image otp 26 elixir 1.16
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.16.3-erlang-26.2.5.13-debian-bookworm-20250630-slim
+          context: ./elixir-ci/debian
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.16.3
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
+
+      - name: Build and push Debian image otp 26 elixir 1.15
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.15.8-erlang-26.2.5.13-debian-bookworm-20250630-slim
+          context: ./elixir-ci/debian
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.15.8
             ERLANG_VERSION=26.2.5.13
             DEBIAN_VERSION=bookworm-20250630-slim

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -67,7 +67,7 @@ jobs:
             ERLANG_VERSION=26.2.5.13
             ALPINE_VERSION=3.20.6
 
-      - name: Build and push Debian image
+      - name: Build and push Debian image otp 26 elixir 1.16
         uses: ./.github/actions/push-image
         with:
           image_name: ghcr.io/multiverse-io/elixir-ci
@@ -77,5 +77,18 @@ jobs:
           lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
           build_args: |
             ELIXIR_VERSION=1.16.3
+            ERLANG_VERSION=26.2.5.13
+            DEBIAN_VERSION=bookworm-20250630-slim
+
+      - name: Build and push Debian image otp 26 elixir 1.15
+        uses: ./.github/actions/push-image
+        with:
+          image_name: ghcr.io/multiverse-io/elixir-ci
+          image_tag: 1.15.8-erlang-26.2.5.13-debian-bookworm-20250630-slim
+          context: ./elixir-ci/debian
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          lacework_access_token: ${{ secrets.LW_ACCESS_TOKEN }}
+          build_args: |
+            ELIXIR_VERSION=1.15.8
             ERLANG_VERSION=26.2.5.13
             DEBIAN_VERSION=bookworm-20250630-slim


### PR DESCRIPTION
Adds elixir-ci image for debian bookworm, otp 26 and elixir 1.15.

The workflow has been split into two jobs as the one long job always failed on the 6th build, regardless of the order of the builds. I'm assuming we're hitting some sort of limit as splitting it works.